### PR TITLE
move ipc_path to /dev/shm

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/mycroft/mycroft.conf
+++ b/buildroot-external/rootfs-overlay/etc/mycroft/mycroft.conf
@@ -1,7 +1,7 @@
 {
   "play_wav_cmdline": "paplay %1",
   "play_mp3_cmdline": "mpg123 %1",
-  "ipc_path": "/ramdisk/mycroft/ipc/",
+  "ipc_path": "/dev/shm/mycroft/ipc/",
   "enclosure": {
     "platform": "OpenVoiceOS",
     "ntp_sync_on_boot": false


### PR DESCRIPTION
`mycroft-skills.service` fails to start when it gets `permission denied`
while trying to create `/ramdisk/mycroft/ipc`. I have confirmed that the
mycroft user has perms to write to `/dev/shm`.