### PR TITLE
fix missed name change in default mycroft.conf

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/mycroft/mycroft.conf
+++ b/buildroot-external/rootfs-overlay/etc/mycroft/mycroft.conf
@@ -12,7 +12,7 @@
   },
   "hotwords": {
     "hey mycroft": {
-      "module": "jarbas_precise_ww_plug",
+      "module": "ovos_ww_plugin_precise",
       "model": "~/.local/share/precise03/hey-mycroft.pb",
       "sensitivity": 0.5,
       "trigger_level": 3,


### PR DESCRIPTION
Somebody should double-check this one, because I am no longer sure this was the only thing I missed. I'm *fairly* sure this was the only thing *from #76*, because @JarbasAl says the pairing skill is responsible for a Chromium name issue, which I can't repro anyway.