### PR TITLE
Update mycroft.conf

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/mycroft/mycroft.conf
+++ b/buildroot-external/rootfs-overlay/etc/mycroft/mycroft.conf
@@ -1,5 +1,5 @@
 {
-  "ready_settings": ["pairing", "skills"],
+  "ready_settings": ["setup", "skills"],
   "confirm_listening": true,
   "play_wav_cmdline": "paplay %1",
   "play_mp3_cmdline": "mpg123 %1",
@@ -67,14 +67,6 @@
       "skill-weather.openvoiceos",
       "ovos-skills-info.openvoiceos"
     ]
-  },
-  "server": {
-    "disabled": false,
-    "url": "https://api.mycroft.ai",
-    "version": "v1",
-    "update": true,
-    "metrics": false,
-    "sync_skill_settings": false
   },
   "Audio": {
     "backends": {


### PR DESCRIPTION
minor update removing now unused sections

"pairing" and "setup" mean the same in config and are both supported, but the intention was to rename pairing to setup so lets adopt that in preparation for the deprecation