### PR TITLE
[RPI] rpi-eeprom: Future support for RPI5

### DIFF
--- a/buildroot-external/package/rpi-eeprom/Config.in
+++ b/buildroot-external/package/rpi-eeprom/Config.in
@@ -1,6 +1,26 @@
 config BR2_PACKAGE_RPI_EEPROM
 	bool "rpi-eeprom"
 	help
-	  EEPROM bootloader firmware for Raspberry Pi 4
+	  EEPROM bootloader firmware for Raspberry Pi 4 and Pi 5
 
 	  https://github.com/raspberrypi/rpi-eeprom
+
+if BR2_PACKAGE_RPI_EEPROM
+
+choice
+	prompt "For Target"
+	default BR2_PACKAGE_RPI_EEPROM_RPI4
+
+config BR2_PACKAGE_RPI_EEPROM_RPI4
+	bool "Raspberry Pi 4"
+	help
+	  For the Raspberry Pi 4
+
+config BR2_PACKAGE_RPI_EEPROM_RPI5
+	bool "Raspberry Pi 5"
+	help
+	  For the Raspberry Pi 5
+
+endchoice
+
+endif

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -3,12 +3,20 @@
 # rpi-eeprom
 #
 #############################################################
-RPI_EEPROM_VERSION = fa281d3be17d1edd2cc10b1d9479cc6b19b96ea8
+RPI_EEPROM_VERSION = 9e0bffb2916d6f31ae454a365bb1b563ee14bf97
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause
 RPI_EEPROM_LICENSE_FILES = LICENSE
 RPI_EEPROM_INSTALL_IMAGES = YES
-RPI_EEPROM_FIRMWARE_PATH = firmware/stable/pieeprom-2023-05-11.bin
+
+# Conditional firmware path based on kernel defconfig
+ifeq ($(BR2_LINUX_KERNEL_DEFCONFIG), "bcm2711") # Raspberry Pi 3/4
+    RPI_EEPROM_FIRMWARE_PATH = firmware-2711/stable/pieeprom-2023-05-11.bin
+else ifeq ($(BR2_LINUX_KERNEL_DEFCONFIG), "bcm2712") # Raspberry Pi 5
+    RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2024-01-05.bin
+else
+    $(error Unsupported Raspberry Pi model for RPI_EEPROM_FIRMWARE_PATH)
+endif
 
 define RPI_EEPROM_BUILD_CMDS
 	$(@D)/rpi-eeprom-config $(@D)/$(RPI_EEPROM_FIRMWARE_PATH) --out $(@D)/default.conf

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -3,19 +3,16 @@
 # rpi-eeprom
 #
 #############################################################
-RPI_EEPROM_VERSION = 9e0bffb2916d6f31ae454a365bb1b563ee14bf97
+RPI_EEPROM_VERSION = 8855da988935f0c09ed4cc772103d4c5408a1afb
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause
 RPI_EEPROM_LICENSE_FILES = LICENSE
 RPI_EEPROM_INSTALL_IMAGES = YES
 
-# Conditional firmware path based on kernel defconfig
-ifeq ($(BR2_LINUX_KERNEL_DEFCONFIG), "bcm2711") # Raspberry Pi 3/4
-    RPI_EEPROM_FIRMWARE_PATH = firmware-2711/stable/pieeprom-2023-05-11.bin
-else ifeq ($(BR2_LINUX_KERNEL_DEFCONFIG), "bcm2712") # Raspberry Pi 5
-    RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2024-01-05.bin
-else
-    $(error Unsupported Raspberry Pi model for RPI_EEPROM_FIRMWARE_PATH)
+ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI4),y)
+	RPI_EEPROM_FIRMWARE_PATH = firmware-2711/stable/pieeprom-2023-05-11.bin
+else ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI5),y) # Raspberry Pi 5
+	RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2024-01-05.bin
 endif
 
 define RPI_EEPROM_BUILD_CMDS


### PR DESCRIPTION
Refactored the EEPROM firmware path handling in the makefile to support specific Raspberry Pi models (bcm2711 for Pi 4 and bcm2712 for Pi 5) with error handling for unsupported models.